### PR TITLE
Positive Flag could cause double negative issues

### DIFF
--- a/src/main/scala/Model.scala
+++ b/src/main/scala/Model.scala
@@ -55,13 +55,10 @@ class Model (
           // The weight of a the child is proportional to the absolute value
           // of its sentiment. It avoid the sentiment to be neutralized by
           // other neutral childs
-          var child_weight = Math.abs(child_sentiment) + ap.baseWeight
+          var child_weight = Math.abs(child_sentiment) * ap.baseWeight
 
           weight = weight + child_weight
-          sentiment = sentiment + child_weight * Math.abs(child_sentiment)
-          if (child_sentiment < -0.0000000001) {
-            positive = positive * -1
-          }
+          sentiment = sentiment + child_weight * child_sentiment
         }
         m(cur) = ( sentiment / weight ) * positive
       }


### PR DESCRIPTION
Great PredictionIO template. Was looking into using this and noticed if you query the engine with a double negative string (ie. {s : "This movie is frustrating and stupid"} the result is a sentiment greater than 2 even if each word by itself is a negative sentiment. 

Believe this is the result of the positive flag - if the tree has an even number of children with negative sentiments, the negative flag gets switched back to positive. I addressed the issue by dropping the positive flag and removing the absolute value when calculating sentiment. 

Thoughts?
